### PR TITLE
修复Bug #50

### DIFF
--- a/src/main/java/com/baomidou/plugin/idea/mybatisx/generate/template/GenerateCode.java
+++ b/src/main/java/com/baomidou/plugin/idea/mybatisx/generate/template/GenerateCode.java
@@ -86,7 +86,12 @@ public class GenerateCode {
         JavaModelGeneratorConfiguration javaModelGeneratorConfiguration = new JavaModelGeneratorConfiguration();
         String targetProject = generateConfig.getModulePath() + "/" + generateConfig.getBasePath();
         javaModelGeneratorConfiguration.setTargetProject(targetProject);
-        javaModelGeneratorConfiguration.setTargetPackage(generateConfig.getBasePackage() + "." + generateConfig.getRelativePackage());
+         
+        if (null != generateConfig.getRelativePackage() && !"".equals(generateConfig.getRelativePackage())) {
+            generateConfig.setRelativePackage("." + generateConfig.getRelativePackage());
+        }
+        javaModelGeneratorConfiguration.setTargetPackage(generateConfig.getBasePackage() + generateConfig.getRelativePackage());
+        
         context.setJavaModelGeneratorConfiguration(javaModelGeneratorConfiguration);
 
         final List<ClassLoader> classLoaderList = new ArrayList<>();


### PR DESCRIPTION
修复当relativePackage为空字符串时，生成实体类时将导致实体类包名以“.”结尾